### PR TITLE
Update go version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/fly-apps/go-example
 
-go 1.16
+go 1.22


### PR DESCRIPTION
Go v1.16 is too old and the docker containers don't build anymore for deploying to fly.io